### PR TITLE
Fixes #3 - feat: add Windows build script for cross-platform support

### DIFF
--- a/EditSuite.spec
+++ b/EditSuite.spec
@@ -35,4 +35,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
+    icon=['icon.ico'],
 )

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -1,0 +1,35 @@
+@echo off
+echo Building EditSuite executable...
+echo.
+
+REM Check if PyInstaller is installed
+python -c "import PyInstaller" 2>nul
+if errorlevel 1 (
+    echo Installing PyInstaller...
+    pip install pyinstaller
+    echo.
+)
+
+REM Create the executable
+echo Creating executable...
+pyinstaller --onefile --windowed --name "EditSuite" --icon=icon.ico EditSuite.py
+
+REM Check if build was successful
+if exist "dist\EditSuite.exe" (
+    echo.
+    echo ✅ Build successful!
+    echo Executable created: dist\EditSuite.exe
+    echo.
+    echo 📋 Important Notes:
+    echo - Users need FFmpeg installed on their system
+    echo - Executable size: ~15-20MB
+    echo - Works on Windows 10+
+    echo.
+    pause
+) else (
+    echo.
+    echo ❌ Build failed!
+    echo Please check the output above for errors.
+    echo.
+    pause
+)


### PR DESCRIPTION
- Create build_exe.bat for Windows users
- Add error handling and PyInstaller dependency check
- Include Windows-specific path handling (.exe extension)
- Maintain feature parity with Linux build.sh script

Fixes #3